### PR TITLE
Add prefix option to avoid type name conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ export default mirrorCreator([
   'ONE_MORE_ACTION_TYPE',
 ]);
 
+// Or you can specify prefix to avoid type name conflicts
+export default mirrorCreator([
+  'SOME_ACTION_TYPE',
+  'ANOTHER_ACTION_TYPE',
+  'ONE_MORE_ACTION_TYPE',
+], { prefix: 'mydomain/' });
+
 // actionCreator.js
 import actionTypes from 'actionTypes';
 

--- a/src/mirrorCreator.js
+++ b/src/mirrorCreator.js
@@ -1,11 +1,12 @@
-export default items => {
+export default (items, options = {}) => {
 
   if (!Array.isArray(items)) {
     throw new Error('mirrorCreator(...): argument must be an array.');
   }
 
+  const { prefix } = options;
   const container = {};
-  items.forEach(item => container[item] = item);
+  items.forEach(item => container[item] = `${(prefix || '')}${item}`);
   return container;
 
 }

--- a/test/mirrorCreator.spec.js
+++ b/test/mirrorCreator.spec.js
@@ -17,4 +17,14 @@ describe('mirrorCreator', () => {
     expect(output.THREE).to.equal('THREE');
   });
 
+
+  it('should return an object with values equal to its prefixed key names', () => {
+    const input  = [ 'ONE', 'TWO', 'THREE' ];
+    const output = mirrorCreator(input, { prefix: 'PREFIX/' });
+
+    expect(output.ONE).to.equal('PREFIX/ONE');
+    expect(output.TWO).to.equal('PREFIX/TWO');
+    expect(output.THREE).to.equal('PREFIX/THREE');
+  });
+
 });


### PR DESCRIPTION
One of good practices for action types is to add application-unique
prefix to avoid name conflicts with third-party libraries.
This commit enables us to do it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/mirror-creator/1)

<!-- Reviewable:end -->
